### PR TITLE
change the builder API to work fluently

### DIFF
--- a/agent-test/src/main/java/app/kanela/instrumentation/MonitorInstrumentation.java
+++ b/agent-test/src/main/java/app/kanela/instrumentation/MonitorInstrumentation.java
@@ -18,18 +18,16 @@ package app.kanela.instrumentation;
 
 import app.kanela.instrumentation.advisor.FakeWorkerAdvisor;
 import app.kanela.instrumentation.mixin.MonitorMixin;
-import kanela.agent.api.instrumentation.KanelaInstrumentation;
+import kanela.agent.api.instrumentation.InstrumentationBuilder;
 
 import static kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.named;
 
-public class MonitorInstrumentation extends KanelaInstrumentation {
+public class MonitorInstrumentation extends InstrumentationBuilder {
     public MonitorInstrumentation() {
-        forTargetType(() -> "app.kanela.FakeWorker", builder ->
-            builder.withMixin(() -> MonitorMixin.class)
-                   .withAdvisorFor(named("heavyTask"), () -> FakeWorkerAdvisor.class)
-                   .withAdvisorFor(named("lightTask"), () -> FakeWorkerAdvisor.class)
-                   .build()
-        );
+        onType("app.kanela.FakeWorker")
+            .mixin(MonitorMixin.class)
+            .advise(named("heavyTask"), FakeWorkerAdvisor.class)
+            .advise(named("lightTask"), FakeWorkerAdvisor.class);
     }
 
 }

--- a/agent-test/src/test/scala/app/kanela/instrumentation/MultiMixinsInstrumentation.scala
+++ b/agent-test/src/test/scala/app/kanela/instrumentation/MultiMixinsInstrumentation.scala
@@ -16,19 +16,15 @@
 
 package app.kanela.instrumentation
 
-import kanela.agent.api.instrumentation.classloader.ClassLoaderRefiner
-import kanela.agent.scala.KanelaInstrumentation
+import kanela.agent.api.instrumentation.InstrumentationBuilder
 
 
-class MultiMixinsInstrumentation extends KanelaInstrumentation {
+class MultiMixinsInstrumentation extends InstrumentationBuilder {
   import app.kanela.instrumentation.mixin.MixinOverMixin._
 
-  forTargetType("app.kanela.cases.multimixins.WithMultiMixinsClass") { builder ⇒
-    builder
-      .withClassLoaderRefiner(ClassLoaderRefiner.mustContains("kanela.agent.scala.KanelaInstrumentation"))
-      .withMixin(classOf[MixinOverMixin1])
-      .withMixin(classOf[MixinOverMixin2])
-      .withMixin(classOf[MixinOverMixin3])
-      .build()
-  }
+  onType("app.kanela.cases.multimixins.WithMultiMixinsClass")
+    .when(classIsPresent("kanela.agent.scala.KanelaInstrumentation"))
+    .mixin(classOf[MixinOverMixin1])
+    .mixin(classOf[MixinOverMixin2])
+    .mixin(classOf[MixinOverMixin3])
 }

--- a/agent-test/src/test/scala/app/kanela/instrumentation/SimpleInstrumentation.scala
+++ b/agent-test/src/test/scala/app/kanela/instrumentation/SimpleInstrumentation.scala
@@ -18,16 +18,15 @@ package app.kanela.instrumentation
 
 import app.kanela.instrumentation.advisor.{SpyAdvisor, TestMethodAdvisor}
 import app.kanela.instrumentation.mixin.SpyMixin
-import kanela.agent.scala.KanelaInstrumentation
+import kanela.agent.api.instrumentation.InstrumentationBuilder
 
-class SimpleInstrumentation extends KanelaInstrumentation {
+class SimpleInstrumentation extends InstrumentationBuilder {
   private val methodName = method("addValue")
-  forTargetType("app.kanela.cases.simple.TestClass") { builder ⇒
-    builder
-      .withMixin(classOf[SpyMixin])
-      .withAdvisorFor(methodName, classOf[TestMethodAdvisor])
-      .withAdvisorFor(methodName, classOf[SpyAdvisor])
-      .build()
-  }
+
+  onType("app.kanela.cases.simple.TestClass")
+    .mixin(classOf[SpyMixin])
+    .advise(methodName, classOf[TestMethodAdvisor])
+    .advise(methodName, classOf[SpyAdvisor])
+
 }
 

--- a/agent-test/src/test/scala/app/kanela/instrumentation/StoppableInstrumentation.scala
+++ b/agent-test/src/test/scala/app/kanela/instrumentation/StoppableInstrumentation.scala
@@ -17,14 +17,11 @@
 package app.kanela.instrumentation
 
 import app.kanela.instrumentation.advisor.TestMethodAdvisor
-import kanela.agent.scala.KanelaInstrumentation
+import kanela.agent.api.instrumentation.InstrumentationBuilder
 
-class StoppableInstrumentation extends KanelaInstrumentation {
+class StoppableInstrumentation extends InstrumentationBuilder {
   val methodName = method("addValue")
 
-  forTargetType("app.kanela.cases.simple.TestClass") { builder ⇒
-    builder
-      .withAdvisorFor(methodName, classOf[TestMethodAdvisor])
-      .build()
-  }
+  onType("app.kanela.cases.simple.TestClass")
+    .advise(methodName, classOf[TestMethodAdvisor])
 }

--- a/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
+++ b/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
@@ -16,7 +16,6 @@
 
 package kanela.agent.builder;
 
-import kanela.agent.api.instrumentation.KanelaInstrumentation;
 import kanela.agent.api.instrumentation.TypeTransformation;
 import kanela.agent.api.instrumentation.listener.InstrumentationRegistryListener;
 import kanela.agent.api.instrumentation.listener.DebugInstrumentationListener;

--- a/agent/src/main/resources/reference.conf
+++ b/agent/src/main/resources/reference.conf
@@ -33,7 +33,7 @@ kanela {
     #     stoppable = true|false (optional)
     #     # Enable restrictions imposed by most VMs and also HotSpot..
     #     disable-class-format-changes = "true|false" (optional)
-    #     # List of fully qualified name of the implementation of kanela.agent.api.instrumentation.KanelaInstrumentation.
+    #     # List of fully qualified name of the implementation of kanela.agent.api.instrumentation.InstrumentationBuilderr.
     #     instrumentations = []
     #     # Only instruments types that are within the list of patterns. e.g. javax.*
     #     within = []

--- a/agent/src/test/scala/kanela/agent/InstrumentationLoaderSpec.scala
+++ b/agent/src/test/scala/kanela/agent/InstrumentationLoaderSpec.scala
@@ -79,7 +79,7 @@ class InstrumentationLoaderSpec extends FlatSpec with Matchers with BeforeAndAft
 
     when(dumpConfigMock.getDumpEnabled).thenReturn(false)
 
-    when(agentModuleDescriptionMock.getInstrumentations).thenReturn(JList.of[String]("kanela.agent.instrumentation.KamonFakeInstrumentation"))
+    when(agentModuleDescriptionMock.getInstrumentations).thenReturn(JList.of[String]("kanela.agent.instrumentation.KamonFakeInstrumentationBuilder"))
     when(agentModuleDescriptionMock.getWithinPackage).thenReturn("")
     when(agentModuleDescriptionMock.getName).thenReturn("x-module")
 

--- a/agent/src/test/scala/kanela/agent/classloader/ClassloaderNameMatcherSpec.scala
+++ b/agent/src/test/scala/kanela/agent/classloader/ClassloaderNameMatcherSpec.scala
@@ -17,7 +17,7 @@
 package kanela.agent.classloader
 
 import io.vavr.control.Option
-import kanela.agent.api.instrumentation.KanelaInstrumentation
+import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.api.instrumentation.classloader.{ClassLoaderRefiner, ClassRefiner}
 import kanela.agent.util.classloader.ClassLoaderNameMatcher.RefinedClassLoaderMatcher
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -26,21 +26,21 @@ class ClassloaderNameMatcherSpec extends Matchers with WordSpecLike with BeforeA
   "The ClassloaderNameMatcher" should {
     "refine the search of a class in an classloader through a ClassRefiner" in {
       val refiner = ClassRefiner.builder()
-        .mustContains("kanela.agent.api.instrumentation.KanelaInstrumentation")
-        .withFields("instrumentationDescriptions", "notDeclaredByObject")
+        .mustContains("kanela.agent.api.instrumentation.InstrumentationBuilder")
+        .withFields("targets", "notDeclaredByObject")
         .withMethod("buildTransformations", "kanela.agent.api.instrumentation.InstrumentationDescription", "kanela.agent.util.conf.KanelaConfiguration$ModuleConfiguration", "java.lang.instrument.Instrumentation")
         .build()
 
       val classLoaderMatcher = RefinedClassLoaderMatcher.from(Option.of(ClassLoaderRefiner.from(refiner)))
 
-      classLoaderMatcher.matches(classOf[KanelaInstrumentation].getClassLoader) shouldBe true
+      classLoaderMatcher.matches(classOf[InstrumentationBuilder].getClassLoader) shouldBe true
     }
 
     "refine the search of a class in an classloader through a list of ClassRefiners" in {
       val refiners = Array[ClassRefiner](
         ClassRefiner.builder()
-          .mustContains("kanela.agent.api.instrumentation.KanelaInstrumentation")
-          .withFields("instrumentationDescriptions", "notDeclaredByObject")
+          .mustContains("kanela.agent.api.instrumentation.InstrumentationBuilder")
+          .withFields("targets", "notDeclaredByObject")
           .withMethod("buildTransformations", "kanela.agent.api.instrumentation.InstrumentationDescription", "kanela.agent.util.conf.KanelaConfiguration$ModuleConfiguration", "java.lang.instrument.Instrumentation")
           .build(),
         ClassRefiner.builder()
@@ -50,31 +50,31 @@ class ClassloaderNameMatcherSpec extends Matchers with WordSpecLike with BeforeA
 
       val classLoaderMatcher = RefinedClassLoaderMatcher.from(Option.of(ClassLoaderRefiner.from(refiners :_*)))
 
-      classLoaderMatcher.matches(classOf[KanelaInstrumentation].getClassLoader) shouldBe true
+      classLoaderMatcher.matches(classOf[InstrumentationBuilder].getClassLoader) shouldBe true
     }
 
     "not match if some of the properties to refine the search not exists" in {
       val classLoaderMatcher = RefinedClassLoaderMatcher.from(Option.of(ClassLoaderRefiner.mustContains("kanela.agent.api.instrumentation.CanelaInstrumentation")))
 
-      classLoaderMatcher.matches(classOf[KanelaInstrumentation].getClassLoader) shouldBe false
+      classLoaderMatcher.matches(classOf[InstrumentationBuilder].getClassLoader) shouldBe false
 
       val fieldRefiner = ClassRefiner.builder()
-        .mustContains("kanela.agent.api.instrumentation.KanelaInstrumentation")
-        .withFields("instrumentationDescriptions", "declaredByObject")
+        .mustContains("kanela.agent.api.instrumentation.InstrumentationBuilder")
+        .withFields("targets", "declaredByObject")
         .build()
 
       val fieldMatcher = RefinedClassLoaderMatcher.from(Option.of(ClassLoaderRefiner.from(fieldRefiner)))
-      fieldMatcher.matches(classOf[KanelaInstrumentation].getClassLoader) shouldBe false
+      fieldMatcher.matches(classOf[InstrumentationBuilder].getClassLoader) shouldBe false
 
 
       val methodRefiner = ClassRefiner.builder()
-        .mustContains("kanela.agent.api.instrumentation.KanelaInstrumentation")
-        .withFields("instrumentationDescriptions", "notDeclaredByObject")
+        .mustContains("kanela.agent.api.instrumentation.InstrumentationBuilder")
+        .withFields("targets", "notDeclaredByObject")
         .withMethod("buildTransformations", "kanela.agent.api.instrumentation.Instrumentation", "kanela.agent.util.conf.KanelaConfiguration$ModuleConfiguration", "java.lang.instrument.Instrumentation")
         .build()
 
       val methodMatcher = RefinedClassLoaderMatcher.from(Option.of(ClassLoaderRefiner.from(methodRefiner)))
-      methodMatcher.matches(classOf[KanelaInstrumentation].getClassLoader) shouldBe false
+      methodMatcher.matches(classOf[InstrumentationBuilder].getClassLoader) shouldBe false
     }
   }
 }

--- a/agent/src/test/scala/kanela/agent/instrumentation/KamonFakeInstrumentationBuilder.scala
+++ b/agent/src/test/scala/kanela/agent/instrumentation/KamonFakeInstrumentationBuilder.scala
@@ -16,6 +16,6 @@
 
 package kanela.agent.instrumentation
 
-import kanela.agent.api.instrumentation.KanelaInstrumentation
+import kanela.agent.api.instrumentation.InstrumentationBuilder
 
-class KamonFakeInstrumentation extends KanelaInstrumentation
+class KamonFakeInstrumentationBuilder extends InstrumentationBuilder

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version:0.0.15
+version: 0.0.17-SNAPSHOT


### PR DESCRIPTION
This changes the previous `KanelaInstrumentation` abstract class into a new `InstrumentationBuilder` abstract class that provides a simpler/friendlier API for defining instrumentations. The basics are pretty much the same as they were before: your first need to define what types are going to be targeted by the instrumentation and then you add transformations to them (advices, mixins and so on), but you wont need to be providing any `Supplier` or lambdas but rather use a simple, fluent API. Here is an example of how the Scala Futures instrumentation was looking like (redacted for simplicity):

```scala
class FutureInstrumentation extends KanelaInstrumentation {

  forTargeType("scala.concurrent.impl.CallbackRunnable") { builder =>
    builder
      .withMixin(classOf[HasContextMixin])
      .withAdvisorFor(method("run"), classOf[RunMethodAdvisor])
      .build()
  }
}
```

and this is how it looks like with the changes on this PR:

```scala
class FutureInstrumentation extends InstrumentationBuilder {

  onType("scala.concurrent.impl.CallbackRunnable")
    .mixin(classOf[HasContext.MixinWithInitializer])
    .advise(method("run"), InvokeWithCapturedContext)

}
```

Now, the changes might not be too visible on a Scala codebase, but trying to use the same API from Java suddenly becomes a lot easier, sadly I don't have Java-based examples at hand.