### PR TITLE
allow specifying exclude patterns on instrumentation modules

### DIFF
--- a/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
+++ b/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
@@ -116,6 +116,7 @@ class KanelaAgentBuilder {
 
     private AgentBuilder withIgnore(AgentBuilder agentBuilder) {
         var builder = agentBuilder.ignore(ignoreMatches())
+                .or(moduleExcludes())
                 .or(any(), isExtensionClassLoader())
                 .or(any(), isKanelaClassLoader())
                 .or(any(), isGroovyClassLoader())
@@ -136,5 +137,9 @@ class KanelaAgentBuilder {
 
     private ElementMatcher.Junction<NamedElement> ignoreMatches() {
         return not(nameMatches(moduleDescription.getWithinPackage()));
+    }
+
+    private ElementMatcher.Junction<NamedElement> moduleExcludes() {
+        return nameMatches(moduleDescription.getExcludePackage());
     }
 }


### PR DESCRIPTION
This adds a new optional `exclude` configuration for modules which can be used to, well, exclude types from being instrumented.