### PR TITLE
delay mixin and bridge initialization until transformations are applied

### DIFF
--- a/agent/src/main/java/kanela/agent/api/instrumentation/InstrumentationBuilder.java
+++ b/agent/src/main/java/kanela/agent/api/instrumentation/InstrumentationBuilder.java
@@ -74,8 +74,8 @@ public abstract class InstrumentationBuilder {
         }
 
         if (moduleConfiguration.shouldInjectInBootstrap()) {
-            val bridgeClasses = bridges.stream().map(BridgeDescription::getIface).collect(Collectors.toList());
-            val mixinClasses = mixins.stream().flatMap(mixinDescription -> mixinDescription.getInterfaces().stream()).collect(Collectors.toList());
+            val bridgeClasses = bridges.stream().map(BridgeDescription::getBridgeInterface).collect(Collectors.toList());
+            val mixinClasses = mixins.stream().map(mixinDescription -> mixinDescription.getMixinClass()).collect(Collectors.toList());
             val advisorClasses = advisors.stream().map(AdvisorDescription::getAdvisorClass).collect(Collectors.toList());
 
             val allClasses = new ArrayList<Class<?>>();

--- a/agent/src/main/java/kanela/agent/api/instrumentation/bridge/BridgeDescription.java
+++ b/agent/src/main/java/kanela/agent/api/instrumentation/bridge/BridgeDescription.java
@@ -28,20 +28,24 @@ import java.util.stream.Collectors;
 
 @Value
 public class BridgeDescription {
-    Class<?> iface;
-    Set<Method> methods;
+    Class<?> bridgeInterface;
 
     public static BridgeDescription of(Class<?> clazz) {
-        val methods =  Arrays.stream(clazz.getDeclaredMethods())
-                .filter(method -> method.isAnnotationPresent(Bridge.class))
-                .collect(Collectors.toSet());
-
-        return new BridgeDescription(clazz, methods);
+        return new BridgeDescription(clazz);
     }
 
     public AgentBuilder.Transformer makeTransformer() {
-        return (builder, typeDescription, classLoader, module) ->
-                builder.implement(new TypeDescription.ForLoadedType(this.iface))
-                       .visit(BridgeClassVisitorWrapper.of(this, typeDescription, classLoader));
+        return (builder, typeDescription, classLoader, module) -> {
+            return builder
+                .implement(new TypeDescription.ForLoadedType(this.bridgeInterface))
+                .visit(BridgeClassVisitorWrapper.of(this, typeDescription, classLoader));
+        };
+
+    }
+
+    public Set<Method> getMethods() {
+        return Arrays.stream(bridgeInterface.getDeclaredMethods())
+            .filter(method -> method.isAnnotationPresent(Bridge.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/agent/src/main/java/kanela/agent/api/instrumentation/mixin/MixinClassVisitor.java
+++ b/agent/src/main/java/kanela/agent/api/instrumentation/mixin/MixinClassVisitor.java
@@ -24,10 +24,8 @@ import net.bytebuddy.jar.asm.*;
 import net.bytebuddy.jar.asm.commons.MethodRemapper;
 import net.bytebuddy.jar.asm.commons.SimpleRemapper;
 import net.bytebuddy.jar.asm.tree.ClassNode;
-import net.bytebuddy.jar.asm.tree.FieldNode;
 import net.bytebuddy.jar.asm.tree.MethodNode;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -57,7 +55,7 @@ public class MixinClassVisitor extends ClassVisitor {
 
     @Override
     public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-        if (name.equals(ConstructorDescriptor) && mixin.getMixinInit().isDefined()) {
+        if (name.equals(ConstructorDescriptor) && mixin.getInitializerMethod().isDefined()) {
             val mv = super.visitMethod(access, name, desc, signature, exceptions);
             return new MixinInitializer(mv, access, name, desc, type, mixin);
         }
@@ -72,7 +70,7 @@ public class MixinClassVisitor extends ClassVisitor {
         // that all classes are loaded with Kanela's ClassLoader (which some times might be the System ClassLoader and
         // some others will be an Attach ClassLoader).
         val classLoader = Thread.currentThread().getContextClassLoader();
-        val mixinClassFileName = mixin.getMixinClass().replace('.', '/') + ".class";
+        val mixinClassFileName = mixin.getMixinClass().getName().replace('.', '/') + ".class";
         val classStream = classLoader.getResourceAsStream(mixinClassFileName);
 
         val cr = new ClassReader(classStream);

--- a/agent/src/main/java/kanela/agent/api/instrumentation/mixin/MixinInitializer.java
+++ b/agent/src/main/java/kanela/agent/api/instrumentation/mixin/MixinInitializer.java
@@ -45,7 +45,7 @@ public class MixinInitializer extends AdviceAdapter {
     @Override
     protected void onMethodExit(int opcode) {
         if (cascadingConstructor) return;
-        mixinDescription.getMixinInit().forEach(methodName -> {
+        mixinDescription.getInitializerMethod().forEach(methodName -> {
             loadThis();
             invokeVirtual(typeClass, new Method(methodName, "()V"));
         });

--- a/agent/src/main/java/kanela/agent/util/classloader/ClassLoaderNameMatcher.java
+++ b/agent/src/main/java/kanela/agent/util/classloader/ClassLoaderNameMatcher.java
@@ -53,7 +53,7 @@ public class ClassLoaderNameMatcher extends ElementMatcher.Junction.AbstractBase
     }
 
     public static ElementMatcher.Junction.AbstractBase<ClassLoader> isSBTPluginClassLoader() {
-        return new ClassLoaderNameMatcher("sbt.internal.PluginManagement.PluginClassLoader");
+        return new ClassLoaderNameMatcher("sbt.internal.PluginManagement$PluginClassLoader");
     }
 
     public static ElementMatcher.Junction.AbstractBase<ClassLoader> isKanelaClassLoader() {


### PR DESCRIPTION
These changes ensure that if we created a mixin/bridge that uses classes that are not present in the classpath, Kanela will not show warnings about failing to load classes.

This happens when, for example, the users have the kamon-bundle in the classpath which contains all instrumentations but the user might not be using all instrumented libraries at once (who would? :D). 