### PR TITLE
gracefully handle modules without a within configuration

### DIFF
--- a/agent/src/main/java/kanela/agent/util/conf/KanelaConfiguration.java
+++ b/agent/src/main/java/kanela/agent/util/conf/KanelaConfiguration.java
@@ -293,7 +293,9 @@ public class KanelaConfiguration {
     }
 
     private String getWithinConfiguration(Config config) {
-        return getTypeListPattern(config, "within").getOrElse(DefaultConfiguration.withinPackage);
+        if(config.hasPath("within"))
+          return getTypeListPattern(config, "within").getOrElse("");
+        return "";
     }
 
     private String getExcludeConfiguration(Config config) {
@@ -349,24 +351,5 @@ public class KanelaConfiguration {
         if (module.enabled) return true;
         Logger.info(() -> "The Module: " + module.getName() + " is disabled");
         return false;
-    }
-
-    private static class DefaultConfiguration {
-        static final String withinPackage = List.of(
-                    "(?!sun\\..*)",
-                    "(?!com\\.sun\\..*)",
-                    "(?!java\\..*)",
-                    "(?!javax\\..*)",
-                    "(?!org\\.aspectj.\\..*)",
-                    "(?!com\\.newrelic.\\..*)",
-                    "(?!org\\.groovy.\\..*)",
-                    "(?!net\\.bytebuddy.\\..*)",
-                    "(?!\\.asm.\\..*)",
-                    "(?!kanela\\.agent\\..*)",
-                    "(?!kamon\\.testkit\\..*)",
-                    "(?!kamon\\.instrumentation\\..*)",
-                    "(?!akka\\.testkit\\..*)",
-                    "(?!org\\.scalatest\\..*)",
-                    "(?!scala\\.(?!concurrent).*)").mkString("", "", ".*");
     }
 }


### PR DESCRIPTION
We were having an issue with the kamon-executors module where the initial value of `within` was like this:

```
within += []
```

This was causing the agent loader to explode and fallback to the default settings, which are targeting ALL classes except for a few known patterns. That default set of classes seems to be leftovers from the time when we were targeting all classes and didn't have excludes so I'm removing it as well. 