### PR TITLE
Remove expiringmap in favour of caffeine

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -29,7 +29,8 @@ configurations {
 
 dependencies {
     compile 'com.typesafe:config:1.3.4'
-    compile 'net.jodah:expiringmap:0.5.9'
+    compile 'com.github.ben-manes.caffeine:caffeine:2.8.5'
+
     compile 'org.tinylog:tinylog:1.3.6'
     compile 'com.github.tobiasrm:tinylog-coloredconsole:1.3.1'
     compile 'net.bytebuddy:byte-buddy-agent:1.10.11'
@@ -79,7 +80,7 @@ shadowJar {
     relocate 'io.vavr', 'kanela.agent.libs.io.vavr'
     relocate 'com.typesafe.config', 'kanela.agent.libs.com.typesafe.config'
     relocate 'org.pmw.tinylog', 'kanela.agent.libs.org.pmw.tinylog'
-    relocate 'net.jodah', 'kanela.agent.libs.net.jodah'
+    relocate 'com.github.ben-manes.caffeine', 'kanela.agent.libs.com.github.ben-manes.caffeine'
 
     relocate ('com.github.tobiasrm', 'kanela.agent.libs.com.github.tobiasrm') {
         exclude 'com.github.tobiasrm.Main.class'

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -29,7 +29,7 @@ configurations {
 
 dependencies {
     compile 'com.typesafe:config:1.3.4'
-    compile 'com.github.ben-manes.caffeine:caffeine:2.8.5'
+    compile 'com.blogspot.mydailyjava:weak-lock-free:0.16'
 
     compile 'org.tinylog:tinylog:1.3.6'
     compile 'com.github.tobiasrm:tinylog-coloredconsole:1.3.1'
@@ -80,7 +80,7 @@ shadowJar {
     relocate 'io.vavr', 'kanela.agent.libs.io.vavr'
     relocate 'com.typesafe.config', 'kanela.agent.libs.com.typesafe.config'
     relocate 'org.pmw.tinylog', 'kanela.agent.libs.org.pmw.tinylog'
-    relocate 'com.github.ben-manes.caffeine', 'kanela.agent.libs.com.github.ben-manes.caffeine'
+    relocate 'com.blogspot.mydailyjava', 'kanela.agent.libs.com.blogspot.mydailyjava'
 
     relocate ('com.github.tobiasrm', 'kanela.agent.libs.com.github.tobiasrm') {
         exclude 'com.github.tobiasrm.Main.class'

--- a/agent/src/main/java/kanela/agent/util/classloader/PreInitializeClasses.java
+++ b/agent/src/main/java/kanela/agent/util/classloader/PreInitializeClasses.java
@@ -19,11 +19,11 @@ package kanela.agent.util.classloader;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.vavr.control.Try;
 import kanela.agent.util.log.Logger;
 import lombok.Value;
 import lombok.val;
-import net.jodah.expiringmap.ExpiringMap;
 
 // This implementation is adapted from:
 // https://github.com/glowroot/glowroot/blob/v0.9.20/agent/core/src/main/java/org/glowroot/agent/weaving/PreInitializeWeavingClasses.java
@@ -56,7 +56,7 @@ public class PreInitializeClasses {
 
     private static void initialize(String type, ClassLoader loader) {
         Try.of(() -> Class.forName(type, true, loader))
-           .onFailure((cause) -> Logger.warn(() -> "class not found: " + type, cause));
+                .onFailure((cause) -> Logger.warn(() -> "class not found: " + type, cause));
     }
 
     public static List<String> usedTypes() {
@@ -127,7 +127,7 @@ public class PreInitializeClasses {
     }
 
     private static void preExpiryMapKeySetAndKeySetIterator() {
-        toPreventDeadCodeElimination = ExpiringMap.builder().build().keySet().iterator();
+        toPreventDeadCodeElimination = Caffeine.newBuilder().build().asMap().keySet().iterator();
     }
 
 }

--- a/agent/src/main/java/kanela/agent/util/classloader/PreInitializeClasses.java
+++ b/agent/src/main/java/kanela/agent/util/classloader/PreInitializeClasses.java
@@ -19,7 +19,7 @@ package kanela.agent.util.classloader;
 import java.util.List;
 import java.util.ArrayList;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
+import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import io.vavr.control.Try;
 import kanela.agent.util.log.Logger;
 import lombok.Value;
@@ -127,7 +127,7 @@ public class PreInitializeClasses {
     }
 
     private static void preExpiryMapKeySetAndKeySetIterator() {
-        toPreventDeadCodeElimination = Caffeine.newBuilder().build().asMap().keySet().iterator();
+        toPreventDeadCodeElimination = new WeakConcurrentMap<Object, Object>(false).iterator();
     }
 
 }


### PR DESCRIPTION
The expiringMap dependency has been replaced with caffeine https://github.com/ben-manes/caffeine. 

This should fix #110. 

I have a small reproduction example, based on https://github.com/akka/akka-samples/tree/2.6/akka-sample-distributed-workers-scala/src/main/scala/worker, and I've been unable to get this PR to deadlock in 2k startups of the app.


All tests pass, most Kamon tests pass (expect for `kamon-annotation`, which depend on `expiringMap` being inside the kanela jar, but  I have that fixed locally and can open another PR if this goes through).

The only downside I see is that the agent jar file has grown in size from 5.4 MB to 6.4 MB.

Check it out and let me know what you think