### PR TITLE
filter out Lagom-related classloaders

### DIFF
--- a/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
+++ b/agent/src/main/java/kanela/agent/builder/KanelaAgentBuilder.java
@@ -124,6 +124,8 @@ class KanelaAgentBuilder {
                 .or(any(), isSBTPluginClassLoader())
                 .or(any(), isSBTCompilerClassLoader())
                 .or(any(), isSBTCachedClassLoader())
+                .or(any(), isLagomClassLoader())
+                .or(any(), isLagomServiceLocatorClassLoader())
                 .or(any(), isReflectionClassLoader());
 
         if (moduleDescription.shouldInjectInBootstrap()) return builder;

--- a/agent/src/main/java/kanela/agent/util/classloader/ClassLoaderNameMatcher.java
+++ b/agent/src/main/java/kanela/agent/util/classloader/ClassLoaderNameMatcher.java
@@ -60,6 +60,14 @@ public class ClassLoaderNameMatcher extends ElementMatcher.Junction.AbstractBase
         return new ClassLoaderNameMatcher("sbt.internal.classpath.ClassLoaderCache$Key$CachedClassLoader");
     }
 
+    public static ElementMatcher.Junction.AbstractBase<ClassLoader> isLagomClassLoader() {
+        return new ClassLoaderNameMatcher("com.lightbend.lagom.dev.NamedURLClassLoader");
+    }
+
+    public static ElementMatcher.Junction.AbstractBase<ClassLoader> isLagomServiceLocatorClassLoader() {
+        return new ClassLoaderNameMatcher("com.lightbend.lagom.sbt.SbtKanelaRunnerLagom$LagomServiceLocatorClassLoader");
+    }
+
     public static ElementMatcher.Junction.AbstractBase<ClassLoader> isSBTCompilerClassLoader() {
         return new ScalaCompilerClassLoaderMatcher();
     }


### PR DESCRIPTION
This PR ensure that two Lagom Class Loaders will not be targeted by Kanela:
  - The Service Locator/Gateway Class Loader
  - The Application Class Loader for any microservice that doesn't have our SBT Lagom Plugin enabled.

This will allow for Kanela to apply instrumentation in development mode to one service at a time.