### PR TITLE
Avoid publication of SHA256 and SHA512 checksums

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
-version: 1.0.12
+version: 1.0.13
+
+# avoid publication of SHA256 and SHA512 checksums
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
* Avoid publication of SHA256 and SHA512 checksums on release, fixes #133 