### PR TITLE
Bump library dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.html
 hs_err_pid*
 
 /agent/src/main/scala/*.sc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,6 @@ please squash them into a single commit. Let the PR rain begin!
 
 
 [open an issue]: https://github.com/kamon-io/Kamon/issues/new
-[mailing list]: https://groups.google.com/forum/#!forum/kamon-user
+[mailing list]: https://groups.google.com/g/kamon-user
 [commit message conventions]: http://spray.io/project-info/contributing/
 [CLA]: https://docs.google.com/forms/d/1G_IDrBTFzOMwHvhxfKRBwNtpRelSa_MZ6jecH8lpTlc/viewform

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -20,8 +20,8 @@ plugins {
     id 'scala'
     id 'maven-publish'
     id 'signing'
-    id 'com.github.maiflai.scalatest' version '0.31'
-    id 'com.github.johnrengelman.shadow' version '7.0.0'
+    id 'com.github.maiflai.scalatest' version '0.32'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 configurations {
@@ -29,7 +29,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'com.typesafe:config:1.3.4'
+    implementation 'com.typesafe:config:1.4.2'
     implementation 'com.blogspot.mydailyjava:weak-lock-free:0.18'
 
     implementation 'org.tinylog:tinylog:1.3.6'
@@ -38,8 +38,8 @@ dependencies {
 
     implementation files('libs/byte-buddy-1.11.18.jar')
 
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'org.scalatest:scalatest_2.12:3.0.1'
+    testImplementation 'org.mockito:mockito-core:2.28.2' // 4.6.x
+    testImplementation 'org.scalatest:scalatest_2.12:3.2.12'
     testImplementation "org.scala-lang:scala-library:${scala_version}"
     testImplementation 'org.pegdown:pegdown:1.6.0'
 }
@@ -48,8 +48,8 @@ def agentBootstrapClasses = 'kanela/agent/bootstrap/**'
 
 task bootstrapJar(type: Jar) {
     // Output to 'bootstrap.jar'.
-    baseName = 'bootstrap'
-    version = null
+    archiveBaseName = 'bootstrap'
+    archiveVersion = null
 
     from sourceSets.main.output
     include agentBootstrapClasses
@@ -58,7 +58,7 @@ task bootstrapJar(type: Jar) {
 shadowJar.dependsOn bootstrapJar
 
 shadowJar {
-    baseName = 'kanela-agent'
+    archiveBaseName = 'kanela-agent'
     classifier = null
 
     mergeServiceFiles {
@@ -88,7 +88,7 @@ shadowJar {
     }
 
     dependencies {
-        exclude('org.projectlombok:lombok:1.18.20')
+        exclude('org.projectlombok:lombok:1.18.24')
     }
 
     doLast {
@@ -123,7 +123,7 @@ def pomConfig = {
     licenses {
         license {
             name "The Apache Software License, Version 2.0"
-            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            url "https://www.apache.org/licenses/LICENSE-2.0.txt"
         }
     }
     developers {
@@ -164,7 +164,7 @@ publishing {
                 def root = asNode()
                 root.appendNode('description', 'The Kamon Instrumentation Agent')
                 root.appendNode('name', 'Kanela')
-                root.appendNode('url', 'http://kamon.io')
+                root.appendNode('url', 'https://kamon.io/')
                 root.children().last() + pomConfig
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.scala_version = '2.12.11'
+    ext.scala_version = '2.12.16'
     ext.agent_version = project(":agent").version
     ext.kamon_agent_dep = "io.kamon:kanela-agent:${agent_version}"
 
@@ -42,13 +42,12 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
-        implementation 'io.vavr:vavr:0.10.3'
-        compileOnly 'org.projectlombok:lombok:1.18.20'
-        annotationProcessor 'org.projectlombok:lombok:1.18.20'
+        implementation 'io.vavr:vavr:0.10.4'
+        compileOnly 'org.projectlombok:lombok:1.18.24'
+        annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
         agent(kamon_agent_dep)
     }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.1.1


### PR DESCRIPTION
Bump scala library: 2.12.16
Bump scalatest: 3.2.12

Bump config dependency: 1.4.2
Bump vavr dependency: 0.10.4
Bump lombok: 1.18.24

Bump plugins: scalatest 0.32 and shadow 7.1.2

Remove sunsetted jcenter repository
Rename deprecated keys: baseName -> archiveBaseName, version -> archiveVersion
Drop ?unused? project/build.properties SBT leftover