### PR TITLE
delay creating temp folders until required for bootstrap injection

### DIFF
--- a/agent/src/main/java/kanela/agent/Kanela.java
+++ b/agent/src/main/java/kanela/agent/Kanela.java
@@ -67,14 +67,15 @@ final public class Kanela {
           runWithTimeSpent(() -> {
               InstrumentationClassPath.build().use(instrumentationClassLoader -> {
                   PreInitializeClasses.preInitializeClasses(instrumentationClassLoader);
-
-                  BootstrapInjector.injectJar(instrumentation, "bootstrap");
-
                   val configuration = KanelaConfiguration.from(instrumentationClassLoader);
+                  KanelaBanner.show(configuration);
                   Logger.configureLogger(configuration);
 
-                  if (isRuntimeAttach) configuration.runtimeAttach();
-                  KanelaBanner.show(configuration);
+                  if(configuration.requiresBootstrapInjection())
+                      BootstrapInjector.injectJar(instrumentation, "bootstrap");
+
+                  if (isRuntimeAttach)
+                      configuration.runtimeAttach();
 
                   installedTransformers = InstrumentationLoader.load(instrumentation, instrumentationClassLoader, configuration);
                   Reinstrumenter.attach(instrumentation, configuration, installedTransformers);

--- a/agent/src/main/java/kanela/agent/Kanela.java
+++ b/agent/src/main/java/kanela/agent/Kanela.java
@@ -117,6 +117,20 @@ final public class Kanela {
   }
 
   /**
+   * Removes all the currently installed transformers without re-scanning to find new transformers. This is meant to be
+   * called during Kamon's initialization when kamon.enabled=no.
+   */
+  public static void disable() {
+      if(Kanela.instrumentation != null) {
+          InstrumentationRegistryListener.instance().clear();
+          InstrumentationClassPath.build().use(instrumentationClassLoader -> {
+              installedTransformers.forEach(transformer -> instrumentation.removeTransformer(transformer.getClassFileTransformer()));
+              installedTransformers = List.empty();
+          });
+      }
+  }
+
+  /**
    * Sets a System property indicating that Kanela has been loaded. That property is meant to be used by external
    * libraries that might want to check whether Kanela was loaded or not.
    */

--- a/agent/src/main/java/kanela/agent/util/conf/KanelaConfiguration.java
+++ b/agent/src/main/java/kanela/agent/util/conf/KanelaConfiguration.java
@@ -31,13 +31,10 @@ import lombok.Value;
 import lombok.val;
 import org.pmw.tinylog.Level;
 
-import java.io.File;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 
 import static io.vavr.API.*;
-import static java.text.MessageFormat.format;
 
 
 @Value
@@ -115,7 +112,7 @@ public class KanelaConfiguration {
                                 stoppable,
                                 bootstrapInjection,
                                 enableClassFileVersionValidator,
-                                createTempDirectory(tempDirPrefix),
+                                tempDirPrefix,
                                 disableClassFormatChanges,
                                 exclude,
                                 exceptionHandlerStrategy);
@@ -133,6 +130,10 @@ public class KanelaConfiguration {
                 .sortBy(ModuleConfiguration::getOrder);
     }
 
+    public boolean requiresBootstrapInjection() {
+        return getAgentModules().exists(m -> m.isEnabled() && m.shouldInjectInBootstrap());
+    }
+
     @Value(staticConstructor = "from")
     public static class ModuleConfiguration {
         String configPath;
@@ -146,7 +147,7 @@ public class KanelaConfiguration {
         BootstrapInjectionConfig bootstrapInjectionConfig;
         @Getter(AccessLevel.NONE)
         boolean enableClassFileVersionValidator;
-        File tempDir;
+        String tempDirPrefix;
         boolean disableClassFormatChanges;
         String excludePackage;
         String exceptionHandlerStrategy;
@@ -302,12 +303,6 @@ public class KanelaConfiguration {
         return ConfigFactory
                 .load(classLoader, ConfigParseOptions.defaults(), ConfigResolveOptions.defaults()
                 .setAllowUnresolved(true));
-    }
-
-    private static File createTempDirectory(String tempDirPrefix) {
-        return Try
-                .of(() -> Files.createTempDirectory(tempDirPrefix).toFile())
-                .getOrElseThrow((cause) -> new RuntimeException(format("Cannot build the temporary directory: {0}", tempDirPrefix), cause));
     }
 
 


### PR DESCRIPTION
This should ensure that Kanela doesn't try to create any temp folders it will not use, so it can run in read-only containers without problems.

In my tests I found that after fixing this, the system metrics module becomes the next problem because it tries to unpack the native libraries for OSHI but that's another topic.