### PR TITLE
avoid warning about the "annotation" module not having anything in within

### DIFF
--- a/agent/src/main/java/kanela/agent/Configuration.java
+++ b/agent/src/main/java/kanela/agent/Configuration.java
@@ -184,7 +184,8 @@ public class Configuration {
                   Optional<List<String>> excludedPrefixes =
                       optionalStringList(moduleConfig, "exclude");
 
-                  if (!prefixes.isPresent()) {
+                  boolean hasNoPrefixes = prefixes.isEmpty() || prefixes.get().isEmpty();
+                  if (hasNoPrefixes && !name.equals("annotation")) {
                     Logger.warn(
                         "Module [{}] doesn't have any prefixes in the 'within' setting. The"
                             + " instrumentations from this module will not have any effect.",


### PR DESCRIPTION
The annotation module is included in the Bundle by default but not used that often and if users don't configure any `within` for it this warning is always shown. We should not waste the user's attention on that.

If we ever want to ignore this warning from other places I might consider introducing a setting for module names that should be fine without prefixes, but this will be fine for now.